### PR TITLE
fix: resize gallery component to fix scroll overflow bug

### DIFF
--- a/src/components/ui/gallery/gallery.css
+++ b/src/components/ui/gallery/gallery.css
@@ -1,7 +1,9 @@
 .gallery-container {
+  height: 65vh;
   display: flex;
   justify-content: flex-start;
   align-items: center;
   flex-wrap: wrap;
   margin: 3%;
+  overflow-y: scroll;
 }

--- a/src/components/ui/header/header.css
+++ b/src/components/ui/header/header.css
@@ -1,6 +1,6 @@
 .header-container {
   width: 100vw;
-  height: 15vw;
+  height: auto;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,7 @@
 html {
   box-sizing: border-box;
 }
+
+*::-webkit-scrollbar {
+  display: none;
+}

--- a/src/pages/temp_data.json
+++ b/src/pages/temp_data.json
@@ -38,5 +38,20 @@
     "id": 8,
     "cuisine_name": "Indian",
     "img_ref": "./food.jpeg"
+  },
+  {
+    "id": 9,
+    "cuisine_name": "Ramen",
+    "img_ref": "./food.jpeg"
+  },
+  {
+    "id": 10,
+    "cuisine_name": "Izakaya",
+    "img_ref": "./food.jpeg"
+  },
+  {
+    "id": 11,
+    "cuisine_name": "Sushi",
+    "img_ref": "./food.jpeg"
   }
 ]


### PR DESCRIPTION
### Summary
---
This pull request adds the following:
- a fix for card overflow

### Details
---
- Previously, when a user scrolls down, the elements were larger than the viewport and so the page would scroll down.
![Screen Shot 2022-10-16 at 8 13 30](https://user-images.githubusercontent.com/66418803/196013602-04a4bf6b-b1dd-495f-8561-685895dbd32f.png)
![Screen Shot 2022-10-16 at 10 35 40](https://user-images.githubusercontent.com/66418803/196013766-2be10459-f3f9-47a5-87f9-b1115ae7fc6e.png)


### References
---
this pull-request addresses issue #3

### Checklist (if merging to `development` or `main`)
---
- [ ] Proposed changes pass testing
- [ ] Stakeholder approval
- [ ] Code reviewer assigned